### PR TITLE
Fix build warnings

### DIFF
--- a/src/Configs/Settings.vala
+++ b/src/Configs/Settings.vala
@@ -10,12 +10,12 @@ namespace App.Configs {
 
         private static AppSettings _settings;
 
-        public static unowned AppSettings get_default () throws Error {
+        public static unowned AppSettings get_default () {
             if (_settings == null) _settings = new AppSettings ();
             return _settings;
         }
 
-        private AppSettings () throws Error {
+        private AppSettings () {
             base ("com.github.bcedu.shutdownscheduler.settings");
         }
     }

--- a/src/Controllers/AppController.vala
+++ b/src/Controllers/AppController.vala
@@ -95,13 +95,13 @@ namespace App.Controllers {
             File f = File.new_for_path (this.get_conf_file());
             try {
 	            f.delete ();
+                f.create(FileCreateFlags.NONE);
+                DataOutputStream writer = new DataOutputStream (f.replace (null, false, FileCreateFlags.NONE));
+                foreach (AddTimeButton btn in add_time_buttons) {
+                    writer.put_string("%d;%s\n".printf (btn.time, btn.units));
+                }
             } catch (Error e) {
 	            print ("Error: %s\n", e.message);
-            }
-            f.create(FileCreateFlags.NONE);
-            DataOutputStream writer = new DataOutputStream (f.replace (null, false, FileCreateFlags.NONE));
-            foreach (AddTimeButton btn in add_time_buttons) {
-                writer.put_string("%d;%s\n".printf (btn.time, btn.units));
             }
         }
 

--- a/src/Views/View2.vala
+++ b/src/Views/View2.vala
@@ -6,7 +6,6 @@ namespace App.Views {
 
         private Gtk.Label remaining_time_lbl;
         private Button cancel_button;
-        private Button conf_button;
 
         public View2 (AppController controler) {
             this.remaining_time_lbl = new Label(_("No shutdown programed"));

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -70,12 +70,8 @@ namespace App {
         private void init_css() {
             // Load CSS
             var provider = new Gtk.CssProvider();
-            try {
-                provider.load_from_resource("/com/github/bcedu/resources/com.github.bcedu.shutdownscheduler.css");
-                Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            } catch (Error e) {
-                stderr.printf("\nError: %s\n", e.message);
-            }
+            provider.load_from_resource("/com/github/bcedu/resources/com.github.bcedu.shutdownscheduler.css");
+            Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         private void load_window_state() {


### PR DESCRIPTION
There's 6 warnings shown when building the app at the moment:

```
../src/Window.vala:82.32-82.56: warning: unhandled error `GLib.Error'
            this.saved_state = AppSettings.get_default();
                               ^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Controllers/AppController.vala:101.13-101.42: warning: unhandled error `GLib.Error'
            f.create(FileCreateFlags.NONE);
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Controllers/AppController.vala:102.61-102.105: warning: unhandled error `GLib.Error'
            DataOutputStream writer = new DataOutputStream (f.replace (null, false, FileCreateFlags.NONE));
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Controllers/AppController.vala:104.17-104.73: warning: unhandled error `GLib.IOError'
                writer.put_string("%d;%s\n".printf (btn.time, btn.units));
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/View2.vala:9.9-9.34: warning: field `App.Views.View2.conf_button' never used
        private Button conf_button;
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Window.vala:76.15-76.29: warning: unreachable catch clause detected
            } catch (Error e) {
              ^^^^^^^^^^^^^^^
```

This PR fixes these error messages are shown.

## Changes Summary

* Remove throwing errors from AppSettings, because it seems other projects don't do it, e.g. [artemanufrij / screencast](https://github.com/artemanufrij/screencast/blob/master/src/Settings.vala) or [stsdc / monitor](https://github.com/stsdc/monitor/blob/master/src/Services/Settings.vala)
* Add `try-catch` in the operations which use `GLib.File`
* Remove never used field `conf_button`
* Remove unnecessary `try-catch` from CSS operations
